### PR TITLE
Clean up Docker run.sh script, add GH Workflow for image updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+on:
+  # push:
+  # pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled'
+        required: false
+        default: false
+
+jobs:
+  build:
+    name: Build, push, and deploy
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup tmate debug session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
+    - name: Build container image
+      run: |
+        docker build \
+        --tag ghcr.io/cp6/my-idlers:$(echo $GITHUB_SHA | head -c7) \
+        --tag ghcr.io/cp6/my-idlers:latest \
+        .
+    - name: Container registry login
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      
+    - name: Push image to GitHub
+      if: github.ref == 'refs/heads/main'
+      run: |
+        docker push ghcr.io/cp6/my-idlers:$(echo $GITHUB_SHA | head -c7)
+        docker push ghcr.io/cp6/my-idlers:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app
 COPY . .
-RUN composer install && \
-    cp .env.example .env
+RUN composer install
 
+ENV APP_ENV production
 ENTRYPOINT ["/app/run.sh"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ docker run \
   -e DB_USERNAME=... \
   -e DB_PASSWORD=... \
   ghcr.io/m3nu/my-idlers:latest  # TODO: adjust after official image is set up!
+docker exec ... php artisan migrate:fresh --seed --force  # Set up database one time
 ```
 
 ## API endpoints

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ removed.
 * Run `php artisan migrate:fresh --seed` to create tables and seed data
 * Run `php artisan serve`
 
+## Run using Docker
+```
+docker run \
+  -p 8000:8000\
+  -e APP_URL=https://... \
+  -e DB_HOST=... \
+  -e DB_DATABASE=... \
+  -e DB_USERNAME=... \
+  -e DB_PASSWORD=... \
+  ghcr.io/m3nu/my-idlers:latest  # TODO: adjust after official image is set up!
+```
+
 ## API endpoints
 
 For GET requests the header must have `Accept: application/json` and your API token (found at `/account`)

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
-# TODO: global env vars aren't used.
-cat > /app/.env.production << EOF
+# Run setup only if .env file doesn't exist.
+if [ ! -e .env.production ]
+then
+cat > .env.production << EOF
 APP_NAME=MyIdlers
 APP_DEBUG=false
 APP_KEY=
@@ -12,10 +14,9 @@ DB_DATABASE=${DB_DATABASE}
 DB_USERNAME=${DB_USERNAME}
 DB_PASSWORD=${DB_PASSWORD}
 APP_URL=${APP_URL}
-ASSET_URL=${ASSET_URL}
 EOF
-
-# TODO: only run this once
-php artisan key:generate
+php artisan key:generate --no-interaction --force
 php artisan migrate:fresh --seed --force
+fi
+
 php artisan serve --host=0.0.0.0 --port=8000 --env=production

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,7 @@ DB_PASSWORD=${DB_PASSWORD}
 APP_URL=${APP_URL}
 EOF
 php artisan key:generate --no-interaction --force
-php artisan migrate:fresh --seed --force
 fi
 
+# php artisan migrate:fresh --seed
 php artisan serve --host=0.0.0.0 --port=8000 --env=production


### PR DESCRIPTION
Supplements my previous PR:

- Fix run.sh to run setup only once (can cause data loss ⚠️)
- Add Docker example in README
- Add Github workflow template to update container (this needs a few settings in your own repo. After it's set up, Docker images can be build on-demand. For versioning, I'd suggest using `2.0-xx` where xx is the container version and 2.0 your app version. Or `2.0-yyyyy` where yyyy is the SHA of the last commit.)