### PR TITLE
Enable Docker image rebuild on every push, add PikaPods hosting option.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,25 +1,15 @@
 on:
-  # push:
-  # pull_request:
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        description: 'Run the build with tmate debugging enabled'
-        required: false
-        default: false
+  push:
 
 jobs:
   build:
     name: Build, push, and deploy
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
 
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Setup tmate debug session
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
     - name: Build container image
       run: |
@@ -31,7 +21,7 @@ jobs:
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       
-    - name: Push image to GitHub
+    - name: Push image to GHCR
       if: github.ref == 'refs/heads/main'
       run: |
         docker push ghcr.io/cp6/my-idlers:$(echo $GITHUB_SHA | head -c7)

--- a/README.md
+++ b/README.md
@@ -83,9 +83,16 @@ docker run \
   -e DB_DATABASE=... \
   -e DB_USERNAME=... \
   -e DB_PASSWORD=... \
-  ghcr.io/m3nu/my-idlers:latest  # TODO: adjust after official image is set up!
+  ghcr.io/cp6/my-idlers:latest
 docker exec ... php artisan migrate:fresh --seed --force  # Set up database one time
 ```
+
+## Managed Hosting
+
+Run with a single click on [PikaPods.com](https://www.pikapods.com/)
+
+[![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=my-idlers)
+
 
 ## API endpoints
 


### PR DESCRIPTION
Noticed that no Docker images are built yet, because it was still set to manual for testing.

Just changed this to build with every push to the main branch. Hope this works. Difficult to test without repo access.

Also added PikaPods.com as hosting option, since there is already a good number of users running it there.