### PR TITLE
yabs: change Ghz to Mhz

### DIFF
--- a/resources/views/servers/compare.blade.php
+++ b/resources/views/servers/compare.blade.php
@@ -55,9 +55,9 @@
                         </tr>
                         <tr>
                             <td class="td-nowrap">CPU freq</td>
-                            <td class="td-nowrap">{{$server1_data[0]->cpu_freq}}<span class="data-type">Ghz</span></td>
-                            {!! \App\Models\Server::tableRowCompare($server1_data[0]->cpu_freq, $server2_data[0]->cpu_freq, 'Ghz') !!}
-                            <td class="td-nowrap">{{$server2_data[0]->cpu_freq}}<span class="data-type">Ghz</span></td>
+                            <td class="td-nowrap">{{$server1_data[0]->cpu_freq}}<span class="data-type">Mhz</span></td>
+                            {!! \App\Models\Server::tableRowCompare($server1_data[0]->cpu_freq, $server2_data[0]->cpu_freq, 'Mhz') !!}
+                            <td class="td-nowrap">{{$server2_data[0]->cpu_freq}}<span class="data-type">Mhz</span></td>
                         </tr>
                         <tr>
                             <td class="td-nowrap">Ram</td>

--- a/resources/views/servers/public-index.blade.php
+++ b/resources/views/servers/public-index.blade.php
@@ -15,7 +15,7 @@
                         <th class="text-center"><i class="fas fa-box" title="Virt"></i></th>
                         <th class="text-center">OS</th>
                         <th class="text-center"><i class="fas fa-microchip" title="CPU"></i></th>
-                        <th class="text-center">Ghz</th>
+                        <th class="text-center">Mhz</th>
                         <th class="text-center"><i class="fas fa-memory" title="ram"></i></th>
                         <th class="text-center"><i class="fas fa-compact-disc" title="disk"></i></th>
                         <th class="text-nowrap">Location</th>

--- a/resources/views/servers/show.blade.php
+++ b/resources/views/servers/show.blade.php
@@ -62,7 +62,7 @@
                                 <td class="px-2 py-2 font-bold text-muted">CPU</td>
                                 <td>
                                     {{ $server_extras[0]->cpu }} @if($server_extras[0]->has_yabs)
-                                        <small>@</small> {{ $server_extras[0]->cpu_freq }} Ghz
+                                        <small>@</small> {{ $server_extras[0]->cpu_freq }} Mhz
                                     @endif</td>
                             </tr>
                             <tr>

--- a/resources/views/yabs/index.blade.php
+++ b/resources/views/yabs/index.blade.php
@@ -42,7 +42,7 @@
                                 <tr>
                                     <td><a href="servers/{{$yab->server_id}}" class="text-decoration-none">{{ $yab->hostname }}</a></td>
                                     <td><span title="{{$yab->cpu_model}}">{{ $yab->cpu_cores }}</span></td>
-                                    <td><span title="{{$yab->cpu_model}}">{{ $yab->cpu_freq }}<small>Ghz</small></span></td>
+                                    <td><span title="{{$yab->cpu_model}}">{{ $yab->cpu_freq }}<small>Mhz</small></span></td>
                                     <td>{{ $yab->ram }}<small>{{ $yab->ram_type }}</small></td>
                                     <td>{{ $yab->disk }}<small>{{ $yab->disk_type }}</small></td>
                                     <td><a href="https://browser.geekbench.com/v5/cpu/{{$yab->gb5_id}}" class="text-decoration-none">{{ $yab->gb5_single }}</a></td>

--- a/resources/views/yabs/show.blade.php
+++ b/resources/views/yabs/show.blade.php
@@ -20,7 +20,7 @@
                                 </tr>
                                 <tr>
                                     <td class="px-4 py-2 font-bold">CPU</td>
-                                    <td>{{ $yab[0]->cpu_cores }} @ {{$yab[0]->cpu_freq}} Ghz</td>
+                                    <td>{{ $yab[0]->cpu_cores }} @ {{$yab[0]->cpu_freq}} Mhz</td>
                                 </tr>
                                 <tr>
                                     <td class="px-4 py-2 font-bold">CPU type</td>


### PR DESCRIPTION
Maybe 10 years later we can revert this commit, for now, let's use Mhz.

`CPU 2 @ 2400Ghz`

![](https://camo.githubusercontent.com/5c78cf5e4491bafea56ab493b12ae0b95f798c5ca7e2f2272134d81fefccd535/68747470733a2f2f63646e2e77726974652e636f72627069652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323032322f30332f4d792d69646c6572732d76322d7365727665722d766965772e6a7067)