### PR TITLE
feat(pricing): add currency api

### DIFF
--- a/resources/views/components/currency-select.blade.php
+++ b/resources/views/components/currency-select.blade.php
@@ -1,12 +1,10 @@
 <div class="input-group">
     <div class="input-group-prepend"><span class="input-group-text">{{ $title ??'Currency'}}</span></div>
     <select class="form-control" name="{{$name ?? 'currency'}}">
-        <option value="AUD" {{(isset($current) && (string)$current === 'AUD')? 'selected' : ''}}>AUD</option>
-        <option value="USD" {{(isset($current) && (string)$current === 'USD')? 'selected' : ''}}>USD</option>
-        <option value="GBP" {{(isset($current) && (string)$current === 'GBP')? 'selected' : ''}}>GBP</option>
-        <option value="EUR" {{(isset($current) && (string)$current === 'EUR')? 'selected' : ''}}>EUR</option>
-        <option value="NZD" {{(isset($current) && (string)$current === 'NZD')? 'selected' : ''}}>NZD</option>
-        <option value="JPY" {{(isset($current) && (string)$current === 'JPY')? 'selected' : ''}}>JPY</option>
-        <option value="CAD" {{(isset($current) && (string)$current === 'CAD')? 'selected' : ''}}>CAD</option>
+        @foreach (App\Models\Pricing::getCurrencyList() as $currency)
+            <option value="{{$currency}}" {{(isset($current) && (string)$current === $currency)? 'selected' : ''}}>
+                {{$currency}}
+            </option>
+        @endforeach
     </select>
 </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -71,7 +71,10 @@
                         <div class="card">
                             <div class="card-body text-center shadow">
                                 <div class="row">
-                                    <h4>{{$information['total_cost_weekly']}} <small class="text-muted">{{$information['currency']}}</small></h4>
+                                    <h4>
+                                        {{$information['total_cost_weekly']}}
+                                        <small class="text-muted">{{$information['currency']}}</small>
+                                    </h4>
                                     <p>Weekly cost</p>
                                 </div>
                             </div>
@@ -81,7 +84,9 @@
                         <div class="card">
                             <div class="card-body text-center shadow">
                                 <div class="row">
-                                    <h4>{{$information['total_cost_monthly']}} <small class="text-muted">{{$information['currency']}}</small>
+                                    <h4>
+                                        {{$information['total_cost_monthly']}}
+                                        <small class="text-muted">{{$information['currency']}}</small>
                                     </h4>
                                     <p>Monthly cost</p>
                                 </div>
@@ -92,7 +97,10 @@
                         <div class="card">
                             <div class="card-body text-center shadow">
                                 <div class="row">
-                                    <h4>{{$information['total_cost_yearly']}} <small class="text-muted">{{$information['currency']}}</small></h4>
+                                    <h4>
+                                        {{$information['total_cost_yearly']}}
+                                        <small class="text-muted">{{$information['currency']}}</small>
+                                    </h4>
                                     <p>Yearly cost</p>
                                 </div>
                             </div>
@@ -102,7 +110,9 @@
                         <div class="card">
                             <div class="card-body text-center shadow">
                                 <div class="row">
-                                    <h4>{{$information['total_cost_2_yearly']}} <small class="text-muted">{{$information['currency']}}</small>
+                                    <h4>
+                                        {{$information['total_cost_2_yearly']}}
+                                        <small class="text-muted">{{$information['currency']}}</small>
                                     </h4>
                                     <p>2 yearly cost</p>
                                 </div>
@@ -388,8 +398,9 @@
 
                 @if(Session::has('timer_version_footer') && Session::get('timer_version_footer') === 1)
                     <p class="text-muted mt-4 text-end"><small>Page took {{$information['execution_time']}} seconds,
-                            Built on Laravel v{{ Illuminate\Foundation\Application::VERSION }} (PHP v{{ PHP_VERSION }}
-                            )</small>
+                            Built on Laravel v{{ Illuminate\Foundation\Application::VERSION }} (PHP v{{ PHP_VERSION }}),
+                            Rates By <a href="https://www.exchangerate-api.com">Exchange Rate API</a>
+                        </small>
                     </p>
                 @endif
     </div>


### PR DESCRIPTION
Based on the [Exchange Rate API](https://www.exchangerate-api.com/), I added support for multi-currency to my-idlers

Their free plan introduction can be found at https://www.exchangerate-api.com/docs/free

A week cache for the currency rate I think we wouldn't trigger their rate limit

To obey their ToS, I added an Attribution to the home page, but I am not sure should we add the Attribution to all the pages with the price field