### PR TITLE
refresh servers cache on due date changed and one other change

### DIFF
--- a/resources/views/servers/index.blade.php
+++ b/resources/views/servers/index.blade.php
@@ -79,7 +79,7 @@
                                         <td class="text-nowrap">{{ $server->provider_name }}</td>
                                         <td class="text-nowrap">{{ $server->price }} {{$server->currency}} {{\App\Process::paymentTermIntToString($server->term)}}</td>
                                         <td class="text-nowrap">
-                                            {{now()->diffInDays(Carbon\Carbon::parse($server->next_due_date))}}
+                                            {{now()->diffInDays(Carbon\Carbon::parse($server->next_due_date), false)}}
                                             <small>days</small></td>
                                         <td class="text-nowrap"> {{ $server->owned_since }}</td>
                                         <td class="text-nowrap">
@@ -187,7 +187,8 @@
                                 @endforeach
                             @else
                                 <tr>
-                                    <td class="px-4 py-2 border text-red-500" colspan="3">No non-active servers found.</td>
+                                    <td class="px-4 py-2 border text-red-500" colspan="3">No non-active servers found.
+                                    </td>
                                 </tr>
                             @endif
                             </tbody>


### PR DESCRIPTION
This PR contains two changes.

1. refresh servers cache on due date changed

When visiting the homepage, it will trigger `doDueSoon()` and extend the due date.

But it didn't clear the server cache, the information didn't change in the following endpoint

```
/servers
/servers/:id
/servers/:id/edit
```

2. show due in date in relative value
 
Or else a server due in 2 days ago will show as due in 2 days later.